### PR TITLE
Add useNodeFocus

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,8 +6,10 @@ import {
   SpatialNavigationNode,
   SpatialNavigationScrollView,
 } from "./lib/src/index";
+import { useNodeFocus } from "./lib/src/useNodeFocus";
 
 export default function App() {
+
   return (
     <SpatialNavigationRoot style={styles.container}>
       <TVDemo />
@@ -16,6 +18,8 @@ export default function App() {
 }
 
 function TVDemo() {
+  const focusNode = useNodeFocus();
+  // usage focusNode('boxA')
   return (
     <View style={styles.inner}>
       {/* Two focusable boxes */}

--- a/lib/src/useNodeFocus.ts
+++ b/lib/src/useNodeFocus.ts
@@ -1,0 +1,11 @@
+// src/useNodeFocus.ts
+import { useContext } from 'react';
+import { SpatialContext } from './SpatialNavigationRoot';
+
+export function useNodeFocus(): (id: string) => void {
+  const ctx = useContext(SpatialContext);
+  if (!ctx) {
+    throw new Error('useNodeFocus must be used within a <SpatialNavigationRoot>');
+  }
+  return ctx.focusNode;
+}


### PR DESCRIPTION
This PR introduces a new custom React hook, useNodeFocus, which allows any component within a SpatialNavigationRoot to programmatically focus a registered navigation node by its ID. It encapsulates the existing focusNode logic from the spatial navigation context into a simple, reusable API.

Key Changes
New Hook

src/useNodeFocus.ts exports useNodeFocus(): (id: string) => void.

Internally retrieves focusNode from SpatialContext, and throws a clear error if used outside of a SpatialNavigationRoot.

Context API Unchanged

No modifications to SpatialNavigationRoot or SpatialNavigationNode components—existing registration/focus logic remains intact.

Consumers of the hook will simply call focusNode(nodeId) where needed.